### PR TITLE
Populate admin view with appointments for the current day

### DIFF
--- a/src/app/admin/admin.component.html
+++ b/src/app/admin/admin.component.html
@@ -1,3 +1,37 @@
 <div class="container">
-  <h1>View Appointments</h1>
+  <div class="card">
+    <div class="card-body">
+      <div class="card" *ngIf="isLoggedIn && isAdmin">
+        <div class="card-body">
+          <h4 class="card-title">Current Appointments</h4>
+          <table class="table">
+            <thead>
+            <tr>
+              <th>Time</th>
+              <th>Room Type</th>
+              <th>Title</th>
+              <th>First Name</th>
+              <th>Last Name</th>
+              <th>Email</th>
+              <th>Phone</th>
+              <th>Notes</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr *ngFor="let appointment of schedule">
+              <td>{{ appointment.time }}</td>
+              <td>{{ appointment.roomType | titlecase }}</td>
+              <td>{{ appointment.title }}</td>
+              <td>{{ appointment.firstName }}</td>
+              <td>{{ appointment.lastName }}</td>
+              <td>{{ appointment.email }}</td>
+              <td>{{ appointment.phoneNumber }}</td>
+              <td>{{ appointment.notes }}</td>
+            </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>

--- a/src/app/admin/admin.component.scss
+++ b/src/app/admin/admin.component.scss
@@ -1,0 +1,15 @@
+table {
+    font-family: arial, sans-serif;
+    border-collapse: collapse;
+    width: 100%;
+}
+  
+td, th {
+    border: 1px solid #dddddd;
+    text-align: left;
+    padding: 8px;
+}
+  
+tr:nth-child(even) {
+    background-color: #dddddd;
+}

--- a/src/app/admin/admin.component.ts
+++ b/src/app/admin/admin.component.ts
@@ -1,6 +1,12 @@
-import { Component, OnInit } from '@angular/core';
+import {
+  Component,
+  OnInit,
+} from '@angular/core';
 
-import { environment } from '../../environments/environment';
+import {AppointmentsService} from '../appointments/appointments.service';
+import {Appointment} from './appointment';
+import {UserService} from '../profile/user.service';
+import {AuthenticationService} from '../core/authentication/authentication.service';
 
 @Component({
   selector: 'app-schedule',
@@ -8,11 +14,37 @@ import { environment } from '../../environments/environment';
   styleUrls: ['./admin.component.scss']
 })
 export class AdminComponent implements OnInit {
+  isLoggedIn: boolean = false;
+  isAdmin: boolean = false;
+  schedule: Array<Appointment>;
 
-  version: string = environment.version;
+  constructor(private authService: AuthenticationService,
+              private userService: UserService,
+              private appointmentsService: AppointmentsService) { }
 
-  constructor() { }
-
-  ngOnInit() { }
+  ngOnInit() {
+    this.isLoggedIn = this.authService.isAuthenticated();
+    if (this.isLoggedIn) {
+      this.userService.getUser().subscribe(
+        user => {
+          this.isAdmin = user.admin;
+          console.log('User is admin: ', this.isAdmin);
+          if (this.isAdmin) {
+            console.log('Getting schedule...');
+            //use Swedish formatting, which is similar to ISO-8601
+            let currentDatePacific = new Date().toLocaleDateString('sv', {timeZone: 'America/Los_Angeles'});
+            this.appointmentsService.getAppointmentScheduleFor(currentDatePacific).subscribe(
+              data => {
+                console.log('Schedule: ', data);
+                this.schedule = data;
+                });
+          }
+        },
+        error => {
+          console.error("Failed to get user!", error);
+          // TODO: show error message
+        });
+    }
+  }
 
 }

--- a/src/app/admin/admin.module.ts
+++ b/src/app/admin/admin.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 
 import {AdminComponent} from './admin.component';
 import {AdminRoutingModule} from './admin-routing.module';
+import {AppointmentsService} from '../appointments/appointments.service';
 
 @NgModule({
   imports: [
@@ -11,6 +12,9 @@ import {AdminRoutingModule} from './admin-routing.module';
   ],
   declarations: [
     AdminComponent
+  ],
+  providers: [
+    AppointmentsService
   ]
 })
 export class AdminModule { }

--- a/src/app/admin/appointment.ts
+++ b/src/app/admin/appointment.ts
@@ -1,0 +1,13 @@
+export class Appointment {
+
+  constructor(
+    public time: string,
+    public title: string,
+    public firstName: string,
+    public lastName: string,
+    public phoneNumber: string,
+    public email: string,
+    public roomType: string,
+    public notes: string
+  ) {  }
+}

--- a/src/app/appointments/appointments.service.ts
+++ b/src/app/appointments/appointments.service.ts
@@ -10,11 +10,13 @@ import { HttpClient } from '@angular/common/http';
 import { AppointmentCreationResponse } from './appointment-creation-response';
 import { stringLiteral } from 'babel-types';
 import { AvailableDateTimeAndType } from './available-datetime-and-type';
+import {Appointment} from '../admin/appointment';
 
 const appointmentsAvailabilityPath = '/api/appointments/availability';
 const appointmentCreationPath = '/api/appointments';
 const appointmentCancellationPath = '/api/appointments/';
 const saveCreditCardPath = '/api/credit-card';
+const adminAppointmentsViewPath = '/api/admin-daily-list';
 
 
 @Injectable()
@@ -42,6 +44,13 @@ export class AppointmentsService {
      return this.http.post<string>(saveCreditCardPath, cardRequest);
   }
 
+  getAppointmentScheduleFor(date: string): Observable<Array<Appointment>> {
+    const request = {
+      date: date
+    };
+    return this.http.post<Array<Appointment>>(adminAppointmentsViewPath, request);
+  }
+
   getAvailabilityMap(): Observable<[Array<AvailableDay>, Map<string, Map<string, Array<AvailableTime>>>]> {
     return this.http.get<Array<AvailableDateTimeAndType>>(appointmentsAvailabilityPath).pipe(map(dateTimeAndTypes => {
       let responseTuple : [Array<AvailableDay>, Map<string, Map<string, Array<AvailableTime>>>];
@@ -51,7 +60,7 @@ export class AppointmentsService {
 
         let momentTime = moment(dateTimeAndType.dateTime);
         let isoDay = momentTime.format("YYYY-MM-DD");
-        
+
         if(!dateToRoomTypeToTimes.has(isoDay)){
           let displayDay = momentTime.format("dddd, MMMM D, Y");
           let availableDay = new AvailableDay(isoDay, displayDay);
@@ -64,7 +73,7 @@ export class AppointmentsService {
         let isoTime = momentTime.format("HH:mm:ss");
         let displayTime = momentTime.format("LT");
         let availabilityTime = new AvailableTime(isoTime, displayTime);
-        
+
         let roomTypeToTimes = dateToRoomTypeToTimes.get(isoDay);
         let roomType = dateTimeAndType.roomType;
         let times = roomTypeToTimes.get(roomType);


### PR DESCRIPTION
Partially addresses these tasks on https://github.com/adamzr/mikvah-api/issues/3:

- [ ] The view appointments page should have a date selector defaulted to today's date
- [ ] There should be a table of appointments for the selected date
- [ ] The table will show the date, time, title, first name, last name, phone number, email address, room type, and notes

This displays appointments for the current date. The next step would be to add a date selector. Here's a sample view of the admin page:

<img width="1371" alt="Screen Shot 2021-10-12 at 9 15 07 AM" src="https://user-images.githubusercontent.com/10815484/136993228-cfbc66f1-399d-4536-9053-8b3934167f1e.png">



  